### PR TITLE
Add test service layer 1er version

### DIFF
--- a/.github/workflows/ManualBuildAndTest.yml
+++ b/.github/workflows/ManualBuildAndTest.yml
@@ -1,0 +1,27 @@
+name: Manual Build and Test.NET
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      Solution_Name: CsvDataMapper.sln
+      Test_Project: CsvDataMapper.Tests.csproj
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+        
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore
+
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/CsvDataMapper.Core/Repositories/CsvRepository.cs
+++ b/CsvDataMapper.Core/Repositories/CsvRepository.cs
@@ -8,7 +8,7 @@ using CsvDataMapper.Core.Utils;
 
 namespace CsvDataMapper.Core.Repositories
 {
-    internal  class CsvRepository: ICsvRepository
+    public  class CsvRepository: ICsvRepository
     {
         private string _csvFilePath;
         private Encoding _encoding = Encoding.UTF8;

--- a/CsvDataMapper.Core/Repositories/Interfaces/ICsvRepository.cs
+++ b/CsvDataMapper.Core/Repositories/Interfaces/ICsvRepository.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace CsvDataMapper.Core.Repositories.Interfaces
 {
-    internal interface ICsvRepository
+    public interface ICsvRepository
     {
         Task<string> ReadCsvFileAsStringAsync();
         string ReadCsvFileAsString();

--- a/CsvDataMapper.Core/Services/CsvService.cs
+++ b/CsvDataMapper.Core/Services/CsvService.cs
@@ -16,7 +16,7 @@ using System.Collections;
 
 namespace CsvDataMapper.Core.Services
 {
-    internal class CsvService : ICsvService
+    public class CsvService : ICsvService
     {
         private readonly ICsvRepository _csvRepository;
         private char _delimiter = ',';

--- a/CsvDataMapper.Core/Services/Interfaces/ICsvService.cs
+++ b/CsvDataMapper.Core/Services/Interfaces/ICsvService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace CsvDataMapper.Core.Services.Interfaces
 {
-    internal interface ICsvService
+    public interface ICsvService
     {
         Task<IList<TModel>> MapCsvToListModelAsync<TModel>() where TModel : new();
         IList<TModel> MapCsvToListModel<TModel>() where TModel : new();

--- a/CsvDataMapper.Tests/CsvDataMapper.Tests.csproj
+++ b/CsvDataMapper.Tests/CsvDataMapper.Tests.csproj
@@ -12,8 +12,9 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.1" />
+    <PackageReference Include="Moq" Version="4.20.70" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CsvDataMapper.Tests/Services/CsvService.Test.cs
+++ b/CsvDataMapper.Tests/Services/CsvService.Test.cs
@@ -1,6 +1,6 @@
 using CsvDataMapper.Core.Repositories.Interfaces;
 using CsvDataMapper.Core.Services.Interfaces;
-using CsvDataMapper.Core.Services
+using CsvDataMapper.Core.Services;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Collections.Generic;

--- a/CsvDataMapper.Tests/Services/CsvService.Test.cs
+++ b/CsvDataMapper.Tests/Services/CsvService.Test.cs
@@ -11,7 +11,7 @@ namespace CsvDataMapper.Tests
   public class CsvServiceTests
   {
     private Mock<ICsvRepository> _csvRepositoryMock;
-    private CsvService _csvService;
+    private ICsvService _csvService;
 
     [TestInitialize]
     public void TestInitialize()

--- a/CsvDataMapper.Tests/Services/CsvService.Test.cs
+++ b/CsvDataMapper.Tests/Services/CsvService.Test.cs
@@ -1,0 +1,143 @@
+using CsvDataMapper.Core.Repositories.Interfaces;
+using CsvDataMapper.Core.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace CsvDataMapper.Tests
+{
+  [TestClass]
+  public class CsvServiceTests
+  {
+    private Mock<ICsvRepository> _csvRepositoryMock;
+    private CsvService _csvService;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+      _csvRepositoryMock = new Mock<ICsvRepository>();
+      _csvService = new CsvService(_csvRepositoryMock.Object, ',', true);
+    }
+
+    [TestMethod]
+    public void MapCsvToListModel_ShouldReturnListOfModels()
+    {
+      // Arrange
+      _csvRepositoryMock.Setup(repo => repo.ReadCsvFileLine()).Returns("header1,header2");
+      _csvRepositoryMock.SetupSequence(repo => repo.ReadCsvFileLine())
+                        .Returns("header1,header2")
+                        .Returns("value1,value2")
+                        .Returns((string)null);
+
+      // Act
+      var result = _csvService.MapCsvToListModel<TestModel>();
+
+      // Assert
+      Assert.IsNotNull(result);
+      Assert.AreEqual(1, result.Count);
+      Assert.AreEqual("value1", result[0].Property1);
+      Assert.AreEqual("value2", result[0].Property2);
+    }
+
+    [TestMethod]
+    public async Task MapCsvToListModelAsync_ShouldReturnListOfModels()
+    {
+      // Arrange
+      _csvRepositoryMock.Setup(repo => repo.ReadCsvFileLineAsync()).ReturnsAsync("header1,header2");
+      _csvRepositoryMock.SetupSequence(repo => repo.ReadCsvFileLineAsync())
+                        .ReturnsAsync("header1,header2")
+                        .ReturnsAsync("value1,value2")
+                        .ReturnsAsync((string)null);
+
+      // Act
+      var result = await _csvService.MapCsvToListModelAsync<TestModel>();
+
+      // Assert
+      Assert.IsNotNull(result);
+      Assert.AreEqual(1, result.Count);
+      Assert.AreEqual("value1", result[0].Property1);
+      Assert.AreEqual("value2", result[0].Property2);
+    }
+
+    [TestMethod]
+    public void ReadCsvAsDynamic_ShouldReturnListOfDictionaries()
+    {
+      // Arrange
+      _csvRepositoryMock.Setup(repo => repo.ReadCsvFileLine()).Returns("header1,header2");
+      _csvRepositoryMock.SetupSequence(repo => repo.ReadCsvFileLine())
+                        .Returns("header1,header2")
+                        .Returns("value1,value2")
+                        .Returns((string)null);
+
+      // Act
+      var result = _csvService.ReadCsvAsDynamic();
+
+      // Assert
+      Assert.IsNotNull(result);
+      Assert.AreEqual(1, result.Count);
+      Assert.AreEqual("value1", result[0]["header1"]);
+      Assert.AreEqual("value2", result[0]["header2"]);
+    }
+
+    [TestMethod]
+    public async Task ReadCsvAsDynamicAsync_ShouldReturnListOfDictionaries()
+    {
+      // Arrange
+      _csvRepositoryMock.Setup(repo => repo.ReadCsvFileLineAsync()).ReturnsAsync("header1,header2");
+      _csvRepositoryMock.SetupSequence(repo => repo.ReadCsvFileLineAsync())
+                        .ReturnsAsync("header1,header2")
+                        .ReturnsAsync("value1,value2")
+                        .ReturnsAsync((string)null);
+
+      // Act
+      var result = await _csvService.ReadCsvAsDynamicAsync();
+
+      // Assert
+      Assert.IsNotNull(result);
+      Assert.AreEqual(1, result.Count);
+      Assert.AreEqual("value1", result[0]["header1"]);
+      Assert.AreEqual("value2", result[0]["header2"]);
+    }
+
+    [TestMethod]
+    public void WriteModelToCsv_ShouldReturnTrue()
+    {
+      // Arrange
+      var models = new List<TestModel>
+            {
+                new TestModel { Property1 = "value1", Property2 = "value2" }
+            };
+      _csvRepositoryMock.Setup(repo => repo.WriteLines(It.IsAny<IEnumerable<string>>())).Returns(true);
+
+      // Act
+      var result = _csvService.WriteModelToCsv(models);
+
+      // Assert
+      Assert.IsTrue(result);
+    }
+
+    [TestMethod]
+    public async Task WriteModelToCsvAsync_ShouldReturnTrue()
+    {
+      // Arrange
+      var models = new List<TestModel>
+      {
+                new TestModel { Property1 = "value1", Property2 = "value2" }
+      };
+      _csvRepositoryMock.Setup(repo => repo.WriteLinesAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(true);
+
+      // Act
+      var result = await _csvService.WriteModelToCsvAsync(models);
+
+      // Assert
+      Assert.IsTrue(result);
+    }
+  }
+
+  public class TestModel
+  {
+    public string Property1 { get; set; }
+    public string Property2 { get; set; }
+  }
+}

--- a/CsvDataMapper.Tests/Services/CsvService.Test.cs
+++ b/CsvDataMapper.Tests/Services/CsvService.Test.cs
@@ -1,5 +1,6 @@
 using CsvDataMapper.Core.Repositories.Interfaces;
-using CsvDataMapper.Core.Services;
+using CsvDataMapper.Core.Services.Interfaces;
+using CsvDataMapper.Core.Services
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.Collections.Generic;


### PR DESCRIPTION
This pull request introduces significant changes to the build and test workflows, updates dependencies, and adds comprehensive unit tests for the `CsvService` class. The most important changes include the addition of a manual build and test workflow, dependency updates, and the creation of extensive unit tests for various methods in the `CsvService` class.

### Workflow Improvements:
* [`.github/workflows/ManualBuildAndTest.yml`](diffhunk://#diff-ec3cba2dcdd6bf1e2f4392f934cd813bc04b08ab2a1faa360a64f5d4479a6650R1-R27): Added a new GitHub Actions workflow for manual build and test of the .NET solution. This includes steps for setting up .NET, restoring dependencies, building the solution, and running tests.

### Dependency Updates:
* [`CsvDataMapper.Tests/CsvDataMapper.Tests.csproj`](diffhunk://#diff-dab63bb65431da882eda1366ece2e64621f2c3f1d861d7b0ba548cb49ba5b24eL15-R17): Updated `MSTest.TestAdapter` and `MSTest.TestFramework` to version 3.6.1 and added a new dependency on `Moq` version 4.20.70.

### Unit Tests:
* [`CsvDataMapper.Tests/Services/CsvService.Test.cs`](diffhunk://#diff-94430991e8d61a8b3ad33003d36f2645c5837260a622533487939bd1cdd7ccf8R1-R143): Added comprehensive unit tests for the `CsvService` class, including tests for synchronous and asynchronous methods such as `MapCsvToListModel`, `ReadCsvAsDynamic`, and `WriteModelToCsv`.